### PR TITLE
Add time-series partitioning and graph query support

### DIFF
--- a/crates/aidb-sql/Cargo.toml
+++ b/crates/aidb-sql/Cargo.toml
@@ -6,3 +6,4 @@ rust-version.workspace = true
 
 [dependencies]
 thiserror = "1"
+chrono = { version = "0.4", features = ["clock"] }


### PR DESCRIPTION
## Summary
- add TIMESTAMP values, time-series partition metadata, and partition-aware filtering for SELECT statements
- extend SQL parsing and execution with graph creation, node/edge insertion, and MATCH queries with property filters
- cover the new functionality with targeted unit tests for time-series ranges and graph traversals

## Testing
- cargo test -p aidb-sql

------
https://chatgpt.com/codex/tasks/task_e_68cddb1ad21883308936982fcbf94861