### PR TITLE
Add savepoints, WAL group commit, and PITR capabilities

### DIFF
--- a/crates/aidb-storage-engine/src/lib.rs
+++ b/crates/aidb-storage-engine/src/lib.rs
@@ -166,7 +166,7 @@ impl StorageEngine {
         let page_guard = page.read().await;
 
         if let Some(row) = page_guard.get_row(row_id.slot_id)? {
-            if row.is_visible(&txn.snapshot) {
+            if row.is_visible(&txn.snapshot()) {
                 self.stats.cache_hits.fetch_add(1, Ordering::Relaxed);
                 return Ok(Some(row));
             }
@@ -187,7 +187,7 @@ impl StorageEngine {
         let mut page_guard = page.write().await;
 
         if let Some(mut row) = page_guard.get_row(row_id.slot_id)? {
-            if !row.is_visible(&txn.snapshot) {
+            if !row.is_visible(&txn.snapshot()) {
                 return Err(StorageEngineError::TransactionConflict(
                     "Row not visible".to_string(),
                 ));
@@ -209,7 +209,7 @@ impl StorageEngine {
         let mut page_guard = page.write().await;
 
         if let Some(mut row) = page_guard.get_row(row_id.slot_id)? {
-            if !row.is_visible(&txn.snapshot) {
+            if !row.is_visible(&txn.snapshot()) {
                 return Ok(false);
             }
 


### PR DESCRIPTION
## Summary
- add transactional savepoints and nested transaction helpers so long-lived transactions can checkpoint and roll back partial work
- rework the WAL pipeline to batch log entries with background group commit flushing and expose recovery metadata for continuous protection
- extend collections with point-in-time recovery/tailing APIs and refresh WAL metrics/tests to account for the buffered log writer

## Testing
- `cargo fmt`
- `cargo test` *(fails: unable to download crates index, CONNECT tunnel 403)*
- `cargo test --offline` *(fails: missing cached dependency `roxmltree`)*

------
https://chatgpt.com/codex/tasks/task_e_68ce07ccbc48833082b08f3ec58dabab