### PR TITLE
Expand quantization test coverage

### DIFF
--- a/crates/aidb-core/src/quantization.rs
+++ b/crates/aidb-core/src/quantization.rs
@@ -451,4 +451,300 @@ mod tests {
         let pq_memory = code.memory_usage();
         assert!(pq_memory < original_memory);
     }
+
+    #[test]
+    #[should_panic(expected = "Dimension must be divisible by m")]
+    fn product_quantizer_new_invalid_dim_panics() {
+        let _ = ProductQuantizer::new(10, 3, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "Quantizer must be trained first")]
+    fn product_quantizer_encode_without_training_panics() {
+        let pq = ProductQuantizer::new(4, 2, 2);
+        let vector = vec![0.0; 4];
+        pq.encode(&vector);
+    }
+
+    #[test]
+    fn product_quantizer_train_empty_data_is_noop() {
+        let dim = 4;
+        let mut pq = ProductQuantizer::new(dim, 2, 2);
+
+        pq.train(&[], 5);
+
+        assert!(!pq.trained);
+        assert!(pq
+            .codebooks
+            .iter()
+            .flatten()
+            .flatten()
+            .all(|&value| value == 0.0));
+    }
+
+    #[test]
+    fn product_quantizer_batch_encode_matches_single_encode() {
+        let dim = 4;
+        let m = 2;
+        let ksub = 2;
+        let mut pq = ProductQuantizer::new(dim, m, ksub);
+
+        let training_vector = vec![1.0, 2.0, 3.0, 4.0];
+        let training_data = vec![training_vector.clone(), training_vector.clone()];
+        pq.train(&training_data, 2);
+        assert!(pq.trained);
+
+        let vectors = vec![
+            training_vector.clone(),
+            vec![1.0, 2.1, 3.0, 4.1],
+            vec![0.0, 0.0, 0.0, 0.0],
+        ];
+
+        let batch = pq.batch_encode(&vectors);
+        let single: Vec<PQCode> = vectors.iter().map(|v| pq.encode(v)).collect();
+
+        assert_eq!(batch.len(), single.len());
+        for (batch_code, single_code) in batch.iter().zip(single.iter()) {
+            assert_eq!(batch_code.codes, single_code.codes);
+        }
+    }
+
+    #[test]
+    fn product_quantizer_batch_encode_empty_input_returns_empty() {
+        let dim = 4;
+        let mut pq = ProductQuantizer::new(dim, 2, 2);
+        let training_vector = vec![1.0, 1.0, 1.0, 1.0];
+        pq.train(&[training_vector.clone(), training_vector], 1);
+        assert!(pq.trained);
+
+        let encoded = pq.batch_encode(&[]);
+        assert!(encoded.is_empty());
+    }
+
+    #[test]
+    fn product_quantizer_asymmetric_distance_matches_decoded_euclidean() {
+        let dim = 4;
+        let mut pq = ProductQuantizer::new(dim, 2, 2);
+
+        let training_vector = vec![1.0, 2.0, 3.0, 4.0];
+        pq.train(&[training_vector.clone(), training_vector.clone()], 1);
+
+        let code = pq.encode(&training_vector);
+        let query = vec![1.5, 1.5, 3.5, 3.5];
+
+        let asymmetric = pq.asymmetric_distance(&query, &code, crate::Metric::Euclidean);
+        let decoded = pq.decode(&code);
+        let expected = crate::distance(&query, &decoded, crate::Metric::Euclidean);
+
+        assert!((asymmetric - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn product_quantizer_asymmetric_distance_matches_cosine() {
+        let dim = 2;
+        let mut pq = ProductQuantizer::new(dim, 1, 1);
+        let training_vector = vec![1.0, 0.0];
+        pq.train(&[training_vector.clone()], 0);
+        assert!(pq.trained);
+
+        let code = pq.encode(&training_vector);
+        let query = vec![0.0, 1.0];
+
+        let distance = pq.asymmetric_distance(&query, &code, crate::Metric::Cosine);
+        let decoded = pq.decode(&code);
+        let expected = crate::distance(&query, &decoded, crate::Metric::Cosine);
+
+        assert!((distance - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn product_quantizer_asymmetric_distance_handles_zero_norm_cosine() {
+        let dim = 4;
+        let mut pq = ProductQuantizer::new(dim, 2, 2);
+
+        let training_vector = vec![1.0, 2.0, 3.0, 4.0];
+        pq.train(&[training_vector.clone(), training_vector.clone()], 1);
+
+        let zero_vector = vec![0.0; dim];
+        let code = pq.encode(&zero_vector);
+        let query = vec![0.0; dim];
+
+        let distance = pq.asymmetric_distance(&query, &code, crate::Metric::Cosine);
+        assert_eq!(distance, 1.0);
+    }
+
+    #[test]
+    fn product_quantizer_train_zero_iterations_marks_trained() {
+        let dim = 4;
+        let mut pq = ProductQuantizer::new(dim, 2, 2);
+        let training_data = vec![vec![1.0, 2.0, 3.0, 4.0], vec![4.0, 3.0, 2.0, 1.0]];
+
+        pq.train(&training_data, 0);
+
+        assert!(pq.trained);
+        assert!(pq
+            .codebooks
+            .iter()
+            .flatten()
+            .flatten()
+            .any(|&value| value != 0.0));
+    }
+
+    #[test]
+    #[should_panic(expected = "Vector dimension mismatch")]
+    fn product_quantizer_encode_dimension_mismatch_panics() {
+        let mut pq = ProductQuantizer::new(4, 2, 2);
+        let training_vector = vec![1.0, 2.0, 3.0, 4.0];
+        pq.train(&[training_vector.clone(), training_vector], 1);
+        pq.encode(&[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Quantizer must be trained first")]
+    fn scalar_quantizer_encode_without_training_panics() {
+        let sq = ScalarQuantizer::new(4);
+        let vector = vec![0.0; 4];
+        sq.encode(&vector);
+    }
+
+    #[test]
+    fn scalar_quantizer_train_empty_data_is_noop() {
+        let mut sq = ScalarQuantizer::new(4);
+        sq.train(&[]);
+        assert!(!sq.trained);
+        assert!(sq.min_vals.iter().all(|&v| v == 0.0));
+        assert!(sq.max_vals.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn scalar_quantizer_roundtrip_and_distances() {
+        let mut sq = ScalarQuantizer::new(4);
+        let training_data = vec![vec![1.0, 2.0, 3.0, 4.0]];
+        sq.train(&training_data);
+        assert!(sq.trained);
+
+        let code = sq.encode(&training_data[0]);
+        let decoded = sq.decode(&code);
+        assert_eq!(decoded, training_data[0]);
+
+        let distance = sq.simd_distance(&training_data[0], &code, crate::Metric::Euclidean);
+        assert!(distance.abs() < 1e-6);
+
+        let cosine_distance = sq.simd_distance(&vec![0.0; 4], &code, crate::Metric::Cosine);
+        assert_eq!(cosine_distance, 1.0);
+    }
+
+    #[test]
+    fn scalar_quantizer_encode_clamps_to_byte_range() {
+        let mut sq = ScalarQuantizer::new(2);
+        let training_data = vec![vec![0.0, 1.0]];
+        sq.train(&training_data);
+
+        let vector = vec![-5.0, 10.0];
+        let code = sq.encode(&vector);
+
+        assert_eq!(code.codes, vec![0, 255]);
+    }
+
+    #[test]
+    fn scalar_quantizer_simd_l2_distance_handles_remainder() {
+        let dim = 10;
+        let mut sq = ScalarQuantizer::new(dim);
+        let base: Vec<f32> = (0..dim).map(|i| i as f32).collect();
+        sq.train(&[base.clone()]);
+        let code = sq.encode(&base);
+        let query: Vec<f32> = base.iter().map(|v| v + 0.25).collect();
+
+        let simd = sq.simd_distance(&query, &code, crate::Metric::Euclidean);
+        let decoded = sq.decode(&code);
+        let expected = crate::distance(&query, &decoded, crate::Metric::Euclidean);
+
+        assert!((simd - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn scalar_quantizer_simd_cosine_distance_matches_manual() {
+        let mut sq = ScalarQuantizer::new(3);
+        let training = vec![vec![1.0, 2.0, 3.0]];
+        sq.train(&training);
+        let code = sq.encode(&training[0]);
+        let query = vec![0.5, 1.0, 1.5];
+
+        let simd = sq.simd_distance(&query, &code, crate::Metric::Cosine);
+        let decoded = sq.decode(&code);
+        let expected = crate::distance(&query, &decoded, crate::Metric::Cosine);
+
+        assert!((simd - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn hybrid_quantizer_selects_strategy_and_delegates_distance() {
+        let dim = 4;
+        let mut hybrid_pq = HybridQuantizer::new(dim, 2, 2, dim);
+        let mut hybrid_sq = HybridQuantizer::new(dim, 2, 2, dim + 1);
+        let training_data = vec![vec![1.0, 2.0, 3.0, 4.0], vec![1.0, 2.0, 3.0, 4.0]];
+
+        hybrid_pq.train(&training_data, 1);
+        hybrid_sq.train(&training_data, 1);
+
+        let vector = training_data[0].clone();
+
+        match hybrid_pq.encode_best(&vector) {
+            QuantizedVector::PQ(code) => {
+                assert_eq!(code.codes.len(), 2);
+                let wrapped = QuantizedVector::PQ(code.clone());
+                let dist = hybrid_pq.distance(&vector, &wrapped, crate::Metric::Euclidean);
+                let decoded = hybrid_pq.pq.decode(&code);
+                let expected = crate::distance(&vector, &decoded, crate::Metric::Euclidean);
+                assert!((dist - expected).abs() < 1e-6);
+            }
+            _ => panic!("expected PQ encoding"),
+        }
+
+        match hybrid_sq.encode_best(&vector) {
+            QuantizedVector::SQ(code) => {
+                assert_eq!(code.codes.len(), dim);
+                let wrapped = QuantizedVector::SQ(code.clone());
+                let dist = hybrid_sq.distance(&vector, &wrapped, crate::Metric::Euclidean);
+                let expected = hybrid_sq
+                    .sq
+                    .simd_distance(&vector, &code, crate::Metric::Euclidean);
+                assert!((dist - expected).abs() < 1e-6);
+            }
+            _ => panic!("expected SQ encoding"),
+        }
+    }
+
+    #[test]
+    fn hybrid_quantizer_distance_cosine_matches_underlying() {
+        let dim = 4;
+        let mut hybrid = HybridQuantizer::new(dim, 2, 2, dim);
+        let training_data = vec![vec![1.0, 2.0, 3.0, 4.0]; 2];
+        hybrid.train(&training_data, 1);
+
+        if let QuantizedVector::PQ(code) = hybrid.encode_best(&training_data[0]) {
+            let wrapped = QuantizedVector::PQ(code.clone());
+            let query = vec![0.5, 1.0, 1.5, 2.0];
+            let distance = hybrid.distance(&query, &wrapped, crate::Metric::Cosine);
+            let decoded = hybrid.pq.decode(&code);
+            let expected = crate::distance(&query, &decoded, crate::Metric::Cosine);
+            assert!((distance - expected).abs() < 1e-6);
+        } else {
+            panic!("expected PQ encoding");
+        }
+
+        let mut hybrid_sq = HybridQuantizer::new(dim, 2, 2, dim + 1);
+        hybrid_sq.train(&training_data, 1);
+        let code = match hybrid_sq.encode_best(&training_data[0]) {
+            QuantizedVector::SQ(code) => code,
+            _ => panic!("expected SQ encoding"),
+        };
+        let wrapped = QuantizedVector::SQ(code.clone());
+        let query = vec![0.5, 1.0, 1.5, 2.0];
+        let distance = hybrid_sq.distance(&query, &wrapped, crate::Metric::Cosine);
+        let expected = hybrid_sq
+            .sq
+            .simd_distance(&query, &code, crate::Metric::Cosine);
+        assert!((distance - expected).abs() < 1e-6);
+    }
 }


### PR DESCRIPTION
## Summary
- add coverage for product quantizer batch encoding, cosine distance parity, zero-iteration training, and dimension mismatch handling
- add scalar quantizer assertions for clamping, SIMD remainder handling, and cosine parity
- ensure hybrid quantizer cosine distance delegation is validated for both PQ and SQ paths

## Testing
- cargo fmt
- cargo test -p aidb-core quantization *(fails: unable to download crates.io index due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0b9fcd5883309dd81d4810abc07c