### PR TITLE
Add external connector support and planner pushdowns

### DIFF
--- a/crates/aidb-sql/src/execution/mod.rs
+++ b/crates/aidb-sql/src/execution/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod scheduler;
 
 pub(crate) use join::parallel_hash_join;
 pub(crate) use operators::{
-    append_rows, apply_predicate, build_batch_for_partition, collect_rows,
-    partition_scan_candidates, BatchPredicate, DEFAULT_BATCH_SIZE,
+    apply_predicate, build_batch_for_partition, collect_rows, partition_scan_candidates,
+    BatchPredicate, DEFAULT_BATCH_SIZE,
 };
 pub(crate) use scheduler::TaskScheduler;

--- a/crates/aidb-sql/src/external/mod.rs
+++ b/crates/aidb-sql/src/external/mod.rs
@@ -1,0 +1,210 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+use crate::{compare_values, ColumnType, Predicate, SqlDatabaseError, Value};
+
+#[derive(Debug, Clone)]
+pub struct ExternalColumn {
+    pub name: String,
+    pub ty: ColumnType,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ExternalCostFactors {
+    pub remote_io_multiplier: f64,
+    pub remote_cpu_multiplier: f64,
+    pub pushdown_selectivity: f64,
+}
+
+impl Default for ExternalCostFactors {
+    fn default() -> Self {
+        Self {
+            remote_io_multiplier: 1.0,
+            remote_cpu_multiplier: 1.0,
+            pushdown_selectivity: 1.0,
+        }
+    }
+}
+
+pub struct ExternalScanRequest<'a> {
+    pub predicate: Option<&'a Predicate>,
+}
+
+pub struct ExternalScanResult {
+    pub rows: Vec<Vec<Value>>,
+    pub pushed_down: bool,
+}
+
+pub trait ExternalSource: Send + Sync {
+    fn schema(&self) -> Vec<ExternalColumn>;
+
+    fn cost_factors(&self) -> ExternalCostFactors {
+        ExternalCostFactors::default()
+    }
+
+    fn supports_predicate_pushdown(&self, _predicate: &Predicate) -> bool {
+        false
+    }
+
+    fn scan(
+        &self,
+        request: ExternalScanRequest<'_>,
+    ) -> Result<ExternalScanResult, SqlDatabaseError>;
+}
+
+pub struct ParquetConnector {
+    columns: Vec<ExternalColumn>,
+    column_indices: HashMap<String, usize>,
+    rows: Vec<Vec<Value>>,
+    cost: ExternalCostFactors,
+    pushdown_calls: AtomicUsize,
+}
+
+impl ParquetConnector {
+    pub fn new(
+        columns: Vec<(&str, ColumnType)>,
+        rows: Vec<Vec<Value>>,
+    ) -> Result<Self, SqlDatabaseError> {
+        if columns.is_empty() {
+            return Err(SqlDatabaseError::SchemaMismatch(
+                "external table requires at least one column".into(),
+            ));
+        }
+        let mut column_defs = Vec::with_capacity(columns.len());
+        let mut indices = HashMap::new();
+        for (index, (name, ty)) in columns.into_iter().enumerate() {
+            column_defs.push(ExternalColumn {
+                name: name.to_string(),
+                ty,
+            });
+            indices.insert(name.to_ascii_lowercase(), index);
+        }
+        for (row_idx, row) in rows.iter().enumerate() {
+            if row.len() != column_defs.len() {
+                return Err(SqlDatabaseError::SchemaMismatch(format!(
+                    "row {row_idx} expected {} values but received {}",
+                    column_defs.len(),
+                    row.len()
+                )));
+            }
+        }
+        Ok(Self {
+            columns: column_defs,
+            column_indices: indices,
+            rows,
+            cost: ExternalCostFactors {
+                remote_io_multiplier: 0.8,
+                remote_cpu_multiplier: 0.7,
+                pushdown_selectivity: 0.3,
+            },
+            pushdown_calls: AtomicUsize::new(0),
+        })
+    }
+
+    pub fn pushdown_call_count(&self) -> usize {
+        self.pushdown_calls.load(AtomicOrdering::SeqCst)
+    }
+
+    fn column_index(&self, name: &str) -> Result<usize, SqlDatabaseError> {
+        self.column_indices
+            .get(&name.to_ascii_lowercase())
+            .copied()
+            .ok_or_else(|| SqlDatabaseError::UnknownColumn(name.to_string()))
+    }
+
+    fn evaluate_predicate(
+        &self,
+        row: &[Value],
+        predicate: &Predicate,
+    ) -> Result<bool, SqlDatabaseError> {
+        match predicate {
+            Predicate::Equals { column, value } => {
+                let idx = self.column_index(column)?;
+                Ok(row[idx] == *value)
+            }
+            Predicate::GreaterOrEqual { column, value } => {
+                let idx = self.column_index(column)?;
+                if matches!(row[idx], Value::Null) {
+                    return Ok(false);
+                }
+                Ok(matches!(
+                    compare_values(&row[idx], value),
+                    Some(Ordering::Greater) | Some(Ordering::Equal)
+                ))
+            }
+            Predicate::Between { column, start, end } => {
+                let idx = self.column_index(column)?;
+                if matches!(row[idx], Value::Null) {
+                    return Ok(false);
+                }
+                let (low, high) = match compare_values(start, end) {
+                    Some(Ordering::Greater) => (end, start),
+                    _ => (start, end),
+                };
+                let cmp_low = compare_values(&row[idx], low);
+                let cmp_high = compare_values(&row[idx], high);
+                Ok(
+                    matches!(cmp_low, Some(Ordering::Greater) | Some(Ordering::Equal))
+                        && matches!(cmp_high, Some(Ordering::Less) | Some(Ordering::Equal)),
+                )
+            }
+            Predicate::IsNull { column } => {
+                let idx = self.column_index(column)?;
+                Ok(matches!(row[idx], Value::Null))
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+impl ExternalSource for ParquetConnector {
+    fn schema(&self) -> Vec<ExternalColumn> {
+        self.columns.clone()
+    }
+
+    fn cost_factors(&self) -> ExternalCostFactors {
+        self.cost
+    }
+
+    fn supports_predicate_pushdown(&self, predicate: &Predicate) -> bool {
+        let column = match predicate {
+            Predicate::Equals { column, .. }
+            | Predicate::GreaterOrEqual { column, .. }
+            | Predicate::Between { column, .. }
+            | Predicate::IsNull { column }
+            | Predicate::InTableColumn { column, .. }
+            | Predicate::FullText { column, .. } => column,
+        };
+        matches!(
+            predicate,
+            Predicate::Equals { .. }
+                | Predicate::GreaterOrEqual { .. }
+                | Predicate::Between { .. }
+                | Predicate::IsNull { .. }
+        ) && self
+            .column_indices
+            .contains_key(&column.to_ascii_lowercase())
+    }
+
+    fn scan(
+        &self,
+        request: ExternalScanRequest<'_>,
+    ) -> Result<ExternalScanResult, SqlDatabaseError> {
+        let mut rows = Vec::new();
+        let mut pushed_down = false;
+        match request.predicate {
+            Some(predicate) if self.supports_predicate_pushdown(predicate) => {
+                pushed_down = true;
+                self.pushdown_calls.fetch_add(1, AtomicOrdering::SeqCst);
+                for row in &self.rows {
+                    if self.evaluate_predicate(row, predicate)? {
+                        rows.push(row.clone());
+                    }
+                }
+            }
+            _ => rows.extend(self.rows.iter().cloned()),
+        }
+        Ok(ExternalScanResult { rows, pushed_down })
+    }
+}

--- a/crates/aidb-sql/src/planner/context.rs
+++ b/crates/aidb-sql/src/planner/context.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(test), allow(dead_code))]
 use std::collections::HashMap;
 
-use crate::{ColumnStatistics, Table, TableStatistics, Value};
+use crate::{ColumnStatistics, ExternalSource, Table, TableStatistics, Value};
 
 use super::table_ref::ResolvedTable;
 
@@ -56,6 +56,7 @@ impl PlanStatistics {
 pub struct PlanContext<'a> {
     pub table: ResolvedTable<'a>,
     stats: PlanStatistics,
+    external: Option<&'a dyn ExternalSource>,
 }
 
 impl<'a> PlanContext<'a> {
@@ -63,6 +64,7 @@ impl<'a> PlanContext<'a> {
         table: ResolvedTable<'a>,
         table_stats: Option<TableStatistics>,
         column_stats: Vec<ColumnStatistics>,
+        external: Option<&'a dyn ExternalSource>,
     ) -> Self {
         let average_row_width = approximate_row_width(table.table);
         let stats = PlanStatistics::new(
@@ -71,11 +73,19 @@ impl<'a> PlanContext<'a> {
             table_stats,
             column_stats,
         );
-        Self { table, stats }
+        Self {
+            table,
+            stats,
+            external,
+        }
     }
 
     pub fn statistics(&self) -> &PlanStatistics {
         &self.stats
+    }
+
+    pub fn external(&self) -> Option<&'a dyn ExternalSource> {
+        self.external
     }
 }
 

--- a/crates/aidb-sql/src/planner/logical.rs
+++ b/crates/aidb-sql/src/planner/logical.rs
@@ -66,6 +66,7 @@ impl<'a> fmt::Debug for FilterExpr<'a> {
 pub struct ScanExpr<'a> {
     pub table: ResolvedTable<'a>,
     pub candidates: ScanCandidates,
+    pub options: ScanOptions,
 }
 
 impl<'a> fmt::Debug for ScanExpr<'a> {
@@ -73,8 +74,14 @@ impl<'a> fmt::Debug for ScanExpr<'a> {
         f.debug_struct("Scan")
             .field("table", &self.table)
             .field("candidates", &self.candidates)
+            .field("options", &self.options)
             .finish()
     }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ScanOptions {
+    pub pushdown_predicate: Option<Predicate>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -105,6 +112,7 @@ impl<'a> LogicalPlanBuilder<'a> {
         let expr = LogicalExpr::Scan(ScanExpr {
             table,
             candidates: ScanCandidates::AllRows,
+            options: ScanOptions::default(),
         });
         Self { current: expr }
     }

--- a/crates/aidb-sql/src/planner/memo.rs
+++ b/crates/aidb-sql/src/planner/memo.rs
@@ -1,7 +1,7 @@
 use crate::{Predicate, SelectColumns};
 
 use super::logical::{
-    FilterExpr, LogicalExpr, LogicalPlan, ProjectionExpr, ScanCandidates, ScanExpr,
+    FilterExpr, LogicalExpr, LogicalPlan, ProjectionExpr, ScanCandidates, ScanExpr, ScanOptions,
 };
 use super::table_ref::ResolvedTable;
 
@@ -24,6 +24,7 @@ pub enum MemoExpr<'a> {
     Scan {
         table: ResolvedTable<'a>,
         candidates: ScanCandidates,
+        options: ScanOptions,
     },
 }
 
@@ -72,6 +73,7 @@ impl<'a> Memo<'a> {
             LogicalExpr::Scan(scan) => self.insert_operator(MemoExpr::Scan {
                 table: scan.table,
                 candidates: scan.candidates,
+                options: scan.options,
             }),
         }
     }
@@ -129,9 +131,14 @@ impl<'a> Memo<'a> {
                     input: Box::new(input_expr),
                 })
             }
-            MemoExpr::Scan { table, candidates } => LogicalExpr::Scan(ScanExpr {
+            MemoExpr::Scan {
+                table,
+                candidates,
+                options,
+            } => LogicalExpr::Scan(ScanExpr {
                 table: *table,
                 candidates: candidates.clone(),
+                options: options.clone(),
             }),
         }
     }

--- a/crates/aidb-sql/src/planner/table_ref.rs
+++ b/crates/aidb-sql/src/planner/table_ref.rs
@@ -8,6 +8,7 @@ pub enum TableSource {
     System,
     Cte,
     MaterializedView,
+    External,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/aidb-sql/tests/federation.rs
+++ b/crates/aidb-sql/tests/federation.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use aidb_sql::{ColumnType, ParquetConnector, QueryResult, SqlDatabase, Value};
+
+fn setup_database() -> (SqlDatabase, Arc<ParquetConnector>) {
+    let mut db = SqlDatabase::new();
+    db.execute("CREATE TABLE residents (id INTEGER, city TEXT)")
+        .unwrap();
+    db.execute("INSERT INTO residents (id, city) VALUES (1, 'Paris'), (2, 'Berlin'), (3, 'Oslo')")
+        .unwrap();
+
+    let connector = Arc::new(
+        ParquetConnector::new(
+            vec![
+                ("city", ColumnType::Text),
+                ("population", ColumnType::Integer),
+            ],
+            vec![
+                vec![Value::Text("Paris".into()), Value::Integer(2_148_000)],
+                vec![Value::Text("Madrid".into()), Value::Integer(3_823_000)],
+                vec![Value::Text("Berlin".into()), Value::Integer(3_769_000)],
+            ],
+        )
+        .expect("connector should be constructed"),
+    );
+
+    db.register_external_table("city_stats", connector.clone())
+        .expect("external table should register");
+
+    (db, connector)
+}
+
+#[test]
+fn federated_filter_uses_external_data() {
+    let (mut db, _connector) = setup_database();
+    let result = db
+        .execute("SELECT id, city FROM residents WHERE city IN city_stats.city")
+        .expect("query should succeed");
+
+    match result {
+        QueryResult::Rows { columns, rows } => {
+            assert_eq!(columns, vec!["id".to_string(), "city".to_string()]);
+            assert_eq!(rows.len(), 2);
+            assert!(rows.contains(&vec![Value::Integer(1), Value::Text("Paris".into())]));
+            assert!(rows.contains(&vec![Value::Integer(2), Value::Text("Berlin".into())]));
+        }
+        other => panic!("unexpected result: {other:?}"),
+    }
+}
+
+#[test]
+fn external_predicates_are_pushed_down() {
+    let (mut db, connector) = setup_database();
+    let result = db
+        .execute("SELECT city FROM city_stats WHERE population BETWEEN 2000000 AND 3500000")
+        .expect("external query should succeed");
+
+    match result {
+        QueryResult::Rows { columns, rows } => {
+            assert_eq!(columns, vec!["city".to_string()]);
+            assert_eq!(rows, vec![vec![Value::Text("Paris".into())]]);
+        }
+        other => panic!("unexpected result: {other:?}"),
+    }
+
+    assert!(connector.pushdown_call_count() > 0);
+}


### PR DESCRIPTION
## Summary
- add an `ExternalSource` abstraction with a sample `ParquetConnector`, pushdown-aware scanning, and connector costing hooks
- extend `SqlDatabase`, predicates, and planner execution to register external tables, normalize case-insensitive lookups, and support new connector-aware filters
- refresh the optimizer and execution pipeline for predicate pushdown and add federation integration tests covering external data access

## Testing
- cargo fmt
- cargo test -p aidb-sql

------
https://chatgpt.com/codex/tasks/task_e_68d086c9d7dc83309949b1744bbfca64